### PR TITLE
Chairs spawn and Newspaper adjustment.

### DIFF
--- a/Assets/HighscoreTable/HighscoreTable.cs
+++ b/Assets/HighscoreTable/HighscoreTable.cs
@@ -29,7 +29,7 @@ public class HighscoreTable : MonoBehaviour
 
     private void Awake()
     {
-        
+        getName.text = PlayerPrefs.GetString("lastName", "");
         scoreCombination = PlayerPrefs.GetInt("score").ToString() + "pts, " + PlayerPrefs.GetInt("height").ToString() + "m";
         displayScore.text = scoreCombination;
 
@@ -144,6 +144,7 @@ public class HighscoreTable : MonoBehaviour
 
     public void SubmitButton()
     {
+        PlayerPrefs.SetString("lastName", getName.text);
         AddHighscoreEntry(PlayerPrefs.GetInt("score"), PlayerPrefs.GetInt("height"), getName.text);
         string jsonString = PlayerPrefs.GetString("highscoreTable");
         Highscores highscores = JsonUtility.FromJson<Highscores>(jsonString);

--- a/Assets/Scenes/BuildingRotation.unity
+++ b/Assets/Scenes/BuildingRotation.unity
@@ -1257,6 +1257,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2e1e4cb2429b2664f9f18c6d070a434f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Player: {fileID: 1088036983}
 --- !u!1 &345423844
 GameObject:
   m_ObjectHideFlags: 0
@@ -1299,7 +1300,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000015258789, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &345423846
@@ -6842,6 +6843,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: LongCleaner
       objectReference: {fileID: 0}
+    - target: {fileID: 5332048958434204545, guid: c374f153fd52aef48bcb1c460075f493, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5980712370758613588, guid: c374f153fd52aef48bcb1c460075f493, type: 3}
       propertyPath: m_CastShadows
       value: 0
@@ -6966,7 +6971,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1905497559012237116, guid: 45b2c9cdd4c78d244b83b973724cc6e1, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 45b2c9cdd4c78d244b83b973724cc6e1, type: 3}

--- a/Assets/_Scripts/HoldAndDrag.cs
+++ b/Assets/_Scripts/HoldAndDrag.cs
@@ -11,6 +11,7 @@ public class HoldAndDrag : MonoBehaviour, IDragHandler
     private float moveTimer = 0.5f;
     private Vector3 startPosition;
     private GameObject obstacleCanvas;
+    public GameObject Player;
 
     private void Start()
     {
@@ -33,6 +34,7 @@ public class HoldAndDrag : MonoBehaviour, IDragHandler
             moveTimer -= Time.deltaTime;
             if (moveTimer < 0)
             {
+                Player.GetComponent<CapsuleCollider>().enabled = true;
                 PaperMoving.onScreen = false;
             }
         }
@@ -44,6 +46,12 @@ public class HoldAndDrag : MonoBehaviour, IDragHandler
             timerActivate = false;
             timer = 1.5f;
             moveTimer = 0.5f;
+        }
+
+        if (PaperMoving.onScreen == true)
+        {
+        //    Time.timeScale /= 2; //Produces an interesting result where it acts more as a slowdown. It seems to resume to the previous speed afterwards but I don't know for sure. Left in for testing purposes.
+            Player.GetComponent<CapsuleCollider>().enabled = false;
         }
 
         if (PlayerHealth.isDead)

--- a/Assets/_Scripts/Spawners/Chairs/EastChairSpawner.cs
+++ b/Assets/_Scripts/Spawners/Chairs/EastChairSpawner.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 public class EastChairSpawner : MonoBehaviour
 {
     public GameObject dirtPrefab;
-    float spawnRate = 1.5f;
-    public float spawnRateTimer = 1.5f;
+    float spawnRate = 2.2f;
+    public float spawnRateTimer = 2.2f;
     private Vector3 dirtPos;
     private float Offset = 2.1f;
     public float newMilestone = 50f;

--- a/Assets/_Scripts/Spawners/Chairs/NorthChairSpawner.cs
+++ b/Assets/_Scripts/Spawners/Chairs/NorthChairSpawner.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 public class NorthChairSpawner : MonoBehaviour
 {
     public GameObject dirtPrefab;
-    float spawnRate = 1.5f;
-    public float spawnRateTimer = 1.5f;
+    float spawnRate = 2.2f;
+    public float spawnRateTimer = 2.2f;
     private Vector3 dirtPos;
     private float Offset = 2.1f;
     public float newMilestone = 50f;

--- a/Assets/_Scripts/Spawners/Chairs/SouthChairSpawner.cs
+++ b/Assets/_Scripts/Spawners/Chairs/SouthChairSpawner.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 public class SouthChairSpawner : MonoBehaviour
 {
     public GameObject dirtPrefab;
-    float spawnRate = 1.5f;
-    public float spawnRateTimer = 1.5f;
+    float spawnRate = 2.2f;
+    public float spawnRateTimer = 2.2f;
     private Vector3 dirtPos;
     private float Offset = 2.1f;
     public float newMilestone = 50f;

--- a/Assets/_Scripts/Spawners/Chairs/WestChairSpawner.cs
+++ b/Assets/_Scripts/Spawners/Chairs/WestChairSpawner.cs
@@ -5,8 +5,8 @@ using UnityEngine;
 public class WestChairSpawner : MonoBehaviour
 {
     public GameObject dirtPrefab;
-    float spawnRate = 1.5f;
-    public float spawnRateTimer = 1.5f;
+    float spawnRate = 2.2f;
+    public float spawnRateTimer = 2.2f;
     private Vector3 dirtPos;
     private float Offset = 2.1f;
     public float newMilestone = 50f;


### PR DESCRIPTION
Chair spawnrate timer increased from 1.5s to 2.2s. Every 50 meters it gets reduced by 0.1. This should make the game a lot easier at the start and ease in obstacles.

Newspaper currently disables your collider until you remove it, losing out on points. Could be abusable and should be tested more.